### PR TITLE
chore: release v0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7](https://github.com/nyurik/noncrypto-digests/compare/v0.3.6...v0.3.7) - 2025-06-11
+
+### Other
+
+- use release-plz token in dependabot ci
+
 ## [0.3.6](https://github.com/nyurik/noncrypto-digests/compare/v0.3.5...v0.3.6) - 2025-06-08
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noncrypto-digests"
-version = "0.3.6"
+version = "0.3.7"
 description = "Implement Digest trait for non-cryptographic hashing functions like fnv and xxhash"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/noncrypto-digests"


### PR DESCRIPTION



## 🤖 New release

* `noncrypto-digests`: 0.3.6 -> 0.3.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.7](https://github.com/nyurik/noncrypto-digests/compare/v0.3.6...v0.3.7) - 2025-06-11

### Other

- use release-plz token in dependabot ci
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).