### PR TITLE
chore: release v0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.8](https://github.com/nyurik/noncrypto-digests/compare/v0.3.7...v0.3.8) - 2025-12-01
+
+### Other
+
+- add .editorconfig
+- minor justfile adjustments
+- *(deps)* bump actions/checkout from 5 to 6 in the all-actions-version-updates group ([#24](https://github.com/nyurik/noncrypto-digests/pull/24))
+- minor justfile adjustments
+
 ## [0.3.7](https://github.com/nyurik/noncrypto-digests/compare/v0.3.6...v0.3.7) - 2025-10-01
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.8](https://github.com/nyurik/noncrypto-digests/compare/v0.3.7...v0.3.8) - 2026-06-18
+
+### Other
+
+- update codecov, justfile, clippy, msrv ([#30](https://github.com/nyurik/noncrypto-digests/pull/30))
+- add .editorconfig
+- minor justfile adjustments
+- *(deps)* bump actions/checkout from 5 to 6 in the all-actions-version-updates group ([#24](https://github.com/nyurik/noncrypto-digests/pull/24))
+- minor justfile adjustments
+
 ## [0.3.7](https://github.com/nyurik/noncrypto-digests/compare/v0.3.6...v0.3.7) - 2025-10-01
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noncrypto-digests"
-version = "0.3.7"
+version = "0.3.8"
 description = "Implement Digest trait for non-cryptographic hashing functions like fnv and xxhash"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/noncrypto-digests"


### PR DESCRIPTION



## 🤖 New release

* `noncrypto-digests`: 0.3.7 -> 0.3.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.8](https://github.com/nyurik/noncrypto-digests/compare/v0.3.7...v0.3.8) - 2026-06-18

### Other

- update codecov, justfile, clippy, msrv ([#30](https://github.com/nyurik/noncrypto-digests/pull/30))
- add .editorconfig
- minor justfile adjustments
- *(deps)* bump actions/checkout from 5 to 6 in the all-actions-version-updates group ([#24](https://github.com/nyurik/noncrypto-digests/pull/24))
- minor justfile adjustments
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).