### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- update to digest 0.11.3 ([#35](https://github.com/nyurik/noncrypto-digests/pull/35))
-- [**breaking**] use digest 0.11 ([#32](https://github.com/nyurik/noncrypto-digests/pull/32))
+- [**breaking**] update to digest 0.11.3 ([#35](https://github.com/nyurik/noncrypto-digests/pull/35))
+- [**breaking**] use 2024 edition ([#32](https://github.com/nyurik/noncrypto-digests/pull/32))
 
 ## [0.3.9](https://github.com/nyurik/noncrypto-digests/compare/v0.3.8...v0.3.9) - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/nyurik/noncrypto-digests/compare/v0.3.9...v0.4.0) - 2026-06-18
+
+### Other
+
+- update to digest 0.11.3 ([#35](https://github.com/nyurik/noncrypto-digests/pull/35))
+- [**breaking**] use digest 0.11 ([#32](https://github.com/nyurik/noncrypto-digests/pull/32))
+
 ## [0.3.9](https://github.com/nyurik/noncrypto-digests/compare/v0.3.8...v0.3.9) - 2026-06-18
 
 - Revert back to Digest 0.10.7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noncrypto-digests"
-version = "0.3.9"
+version = "0.4.0"
 description = "Implement Digest trait for non-cryptographic hashing functions like fnv and xxhash"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/noncrypto-digests"


### PR DESCRIPTION



## 🤖 New release

* `noncrypto-digests`: 0.3.9 -> 0.4.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/nyurik/noncrypto-digests/compare/v0.3.9...v0.4.0) - 2026-06-18

### Other

- update to digest 0.11.3 ([#35](https://github.com/nyurik/noncrypto-digests/pull/35))
- [**breaking**] use digest 0.11 ([#32](https://github.com/nyurik/noncrypto-digests/pull/32))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).